### PR TITLE
fix AUR install instructions (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@
 togo is pushed to arch [AUR](https://aur.archlinux.org/packages/togo) with **zero** dependencies.
 
 ```bash
-yay -Sy togo
-#or
-paru -Sy togo
+yay -S togo
+# or
+paru -S togo
 ```
 
 ### pre-built binaries (recommended)


### PR DESCRIPTION
`pacman -Sy <PKG>` is a partial upgrade that is not supported on Arch:

https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported

`pacman -S <PKG>` is the right way to install a package:

https://wiki.archlinux.org/title/Pacman#Installing_specific_packages