### PR TITLE
Add feature to allow editing an existing task

### DIFF
--- a/model/todo.go
+++ b/model/todo.go
@@ -102,6 +102,15 @@ func (tl *TodoList) findIndexByID(id int) int {
 	return -1
 }
 
+func (tl *TodoList) Edit(id int, newTitle string) bool {
+	idx := tl.findIndexByID(id)
+	if idx == -1 {
+		return false
+	}
+	tl.Todos[idx].Title = newTitle
+	return true
+}
+
 func (tl *TodoList) Toggle(id int) bool {
 	idx := tl.findIndexByID(id)
 	if idx == -1 {

--- a/ui/model.go
+++ b/ui/model.go
@@ -14,6 +14,7 @@ const (
 	ModeDeleteConfirm
 	ModeArchiveConfirm
 	ModeAddTask
+	ModeEditTask
 )
 
 type TodoTableModel struct {
@@ -23,6 +24,7 @@ type TodoTableModel struct {
 	confirmAction    string
 	actionTitle      string
 	viewTaskID       int
+	editTaskID       int
 	width            int
 	height           int
 	selectedTodoIDs  map[int]bool

--- a/ui/update.go
+++ b/ui/update.go
@@ -113,6 +113,28 @@ func (m TodoTableModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.textInput, cmd = m.textInput.Update(msg)
 		return m, cmd
+	case ModeEditTask:
+		switch msg := msg.(type) {
+		case tea.KeyMsg:
+			switch msg.String() {
+			case "enter":
+				title := strings.TrimSpace(m.textInput.Value())
+				if title != "" {
+					m.todoList.Edit(m.editTaskID, title)
+					m.updateRows()
+					m.SetStatusMessage("Task updated")
+				}
+				m.textInput.Reset()
+				m.mode = ModeNormal
+				return m, m.forceRelayoutCmd()
+			case "esc":
+				m.textInput.Reset()
+				m.mode = ModeNormal
+				return m, nil
+			}
+		}
+		m.textInput, cmd = m.textInput.Update(msg)
+		return m, cmd
 	case ModeNormal:
 		switch msg := msg.(type) {
 		case tea.KeyMsg:
@@ -249,6 +271,22 @@ func (m TodoTableModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						}
 					}
 				}
+			case "e":
+				if len(m.table.Rows()) > 0 {
+					selectedTitle := m.table.SelectedRow()[1]
+					cleanTitle := strings.ReplaceAll(selectedTitle, archivedStyle.Render(""), "")
+
+					for _, todo := range m.todoList.Todos {
+						if strings.Contains(selectedTitle, todo.Title) || todo.Title == cleanTitle {
+							m.editTaskID = todo.ID
+							m.textInput.SetValue(todo.Title)
+							m.textInput.Focus()
+							m.mode = ModeEditTask
+							return m, textinput.Blink
+						}
+					}
+				}
+				return m, nil
 			case "a":
 				m.mode = ModeAddTask
 				m.textInput.Focus()

--- a/ui/view.go
+++ b/ui/view.go
@@ -55,6 +55,13 @@ func (m TodoTableModel) View() string {
 				helpStyle.Render("Press Enter to save, Esc to cancel"))
 		return fullScreenStyle.Width(m.width).Height(m.height).Render(inputView)
 	}
+	if m.mode == ModeEditTask {
+		inputView := inputStyle.Render(
+			inputPromptStyle.Render("Edit Task") + "\n\n" +
+				m.textInput.View() + "\n\n" +
+				helpStyle.Render("Press Enter to save, Esc to cancel"))
+		return fullScreenStyle.Width(m.width).Height(m.height).Render(inputView)
+	}
 	if len(m.todoList.Todos) == 0 {
 		return baseStyle.Render("No tasks found. Press 'a' to add a new task!")
 	}
@@ -107,6 +114,7 @@ func (m TodoTableModel) View() string {
 			"→ " + confirmBtnStyle.Render("t") + ": toggle completion" +
 			"\n→ " + confirmBtnStyle.Render("n") + ": toggle archive/unarchive" +
 			"\n→ " + confirmBtnStyle.Render("d") + ": delete" +
+			"\n→ " + confirmBtnStyle.Render("e") + ": edit task" +
 			"\n→ " + confirmBtnStyle.Render("space") + ": select" +
 			"\n→ " + confirmBtnStyle.Render("enter") + ": view details" +
 			"\n→ " + confirmBtnStyle.Render("a") + ": add new task" +


### PR DESCRIPTION
It's useful to be able to modify an existing todo in some scenarios, this commit allows just that.

There is a new mode added, ModeEditTask, triggered with the "e" keybind which opens a textInput box to edit the single selected todo title.