### PR TITLE
fix: correct add usage message

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -15,7 +15,7 @@ var addCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			fmt.Println("Error: Todo title is required")
-			fmt.Println("Usage: todooo add <title>")
+			fmt.Println("Usage: togo add <title>")
 			os.Exit(1)
 		}
 		title := strings.Join(args, " ")


### PR DESCRIPTION
Changed the wrong error message for the add command from 
```Usage: todooo add <title>``` to ```Usage: togo add <title>``` 